### PR TITLE
Spp-9474-adding-pypi-release-to-artifact-release

### DIFF
--- a/.github/workflows/package-release-artifact.yml
+++ b/.github/workflows/package-release-artifact.yml
@@ -39,3 +39,10 @@ jobs:
             sml-python-small.version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: pypi-publish
+        uses: pypa/gh-action-pypi-publish@v1.8.10
+        environment:
+          name: pypi
+          url: https://pypi.org/p/sml-python-small-test
+        permissions:
+          id-token: write


### PR DESCRIPTION
## Synopsis

adds a pypi release to the released code, note this is currently going to a personal account to confirm release is working until we have access to the SPP pypi account

## Checklist

- [ ] Documentation created/updated
- [ ] Tests created/updated

## Description

Add a more detailed description of the pr including any necessary background
information.
