### PR TITLE
Modify Pandas Formatting in Example Code

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -214,14 +214,14 @@ pyflakes = ">=2.5.0,<2.6.0"
 
 [[package]]
 name = "gitdb"
-version = "4.0.10"
+version = "4.0.11"
 description = "Git Object Database"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "gitdb-4.0.10-py3-none-any.whl", hash = "sha256:c286cf298426064079ed96a9e4a9d39e7f3e9bf15ba60701e95f5492f28415c7"},
-    {file = "gitdb-4.0.10.tar.gz", hash = "sha256:6eb990b69df4e15bad899ea868dc46572c3f75339735663b81de79b06f17eb9a"},
+    {file = "gitdb-4.0.11-py3-none-any.whl", hash = "sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4"},
+    {file = "gitdb-4.0.11.tar.gz", hash = "sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b"},
 ]
 
 [package.dependencies]
@@ -229,14 +229,14 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.37"
+version = "3.1.40"
 description = "GitPython is a Python library used to interact with Git repositories"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "GitPython-3.1.37-py3-none-any.whl", hash = "sha256:5f4c4187de49616d710a77e98ddf17b4782060a1788df441846bddefbb89ab33"},
-    {file = "GitPython-3.1.37.tar.gz", hash = "sha256:f9b9ddc0761c125d5780eab2d64be4873fc6817c2899cbcb34b02344bdc7bc54"},
+    {file = "GitPython-3.1.40-py3-none-any.whl", hash = "sha256:cf14627d5a8049ffbf49915732e5eddbe8134c3bdb9d476e6182b676fc573f8a"},
+    {file = "GitPython-3.1.40.tar.gz", hash = "sha256:22b126e9ffb671fdd0c129796343a02bf67bf2994b35449ffc9321aa755e18a4"},
 ]
 
 [package.dependencies]
@@ -244,7 +244,7 @@ gitdb = ">=4.0.1,<5"
 typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.8\""}
 
 [package.extras]
-test = ["black", "coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mypy", "pre-commit", "pytest", "pytest-cov", "pytest-sugar"]
+test = ["black", "coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit", "pytest", "pytest-cov", "pytest-instafail", "pytest-subtests", "pytest-sugar"]
 
 [[package]]
 name = "importlib-metadata"
@@ -597,14 +597,14 @@ plugins = ["importlib-metadata"]
 
 [[package]]
 name = "pytest"
-version = "7.4.2"
+version = "7.4.3"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.4.2-py3-none-any.whl", hash = "sha256:1d881c6124e08ff0a1bb75ba3ec0bfd8b5354a01c194ddd5a0a870a48d99b002"},
-    {file = "pytest-7.4.2.tar.gz", hash = "sha256:a766259cfab564a2ad52cb1aae1b881a75c3eb7e34ca3779697c23ed47c47069"},
+    {file = "pytest-7.4.3-py3-none-any.whl", hash = "sha256:0d009c083ea859a71b76adf7c1d502e4bc170b80a8ef002da5806527b9591fac"},
+    {file = "pytest-7.4.3.tar.gz", hash = "sha256:d989d136982de4e3b29dabcc838ad581c64e8ed52c11fbe86ddebd9da0818cd5"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sml_small"
-version = "1.1.0rc8"
+version = "1.1.0rc9"
 description = "SML Small (Python Pandas methods)"
 authors = []
 readme= "README.md"
@@ -29,9 +29,6 @@ bandit = "^1.7.5"
 [tool.bandit]
 exclude_dirs = ["tests"]
 
-[tool.pytest.ini_options]
-junit_test_suite_name = "sml_small"
-addopts = "--cov=sml_small --cov-fail-under=90 --cov-config=.coveragerc"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/sml_small/editing/thousand_pounds/README.md
+++ b/sml_small/editing/thousand_pounds/README.md
@@ -42,7 +42,7 @@ def thousand_pounds(
     auxiliary: Optional[float],  # Calculated response for the 'previous' period
     upper_limit: float,  # Upper bound of 'error value' threshold
     lower_limit: float,  # Lower bound of 'error value' threshold
-    target_variables: List[Target_variable], # identifier/value pairs
+    target_variables: List[TargetVariable], # identifier/value pairs
     precision: Optional[int],  #Precision is used by the decimal package to ensure a specified accuracy
     # used throughout method processing
 )
@@ -69,14 +69,14 @@ output = thousand_pounds(
 ## Output
 
 ```python
-Thousands_output(
+ThousandPoundsOutput(
     principal_identifier='12340000001-201409-q100',
     principal_adjusted_value="50000.0",
     target_variables=[
-        Target_variable(identifier='101', original_value="500", adjusted_value="0.5"),
-        Target_variable(identifier='102', original_value="1000", adjusted_value="1.0"),
-        Target_variable(identifier='103', original_value="1500", adjusted_value="1.5"),
-        Target_variable(identifier='104', original_value=None, adjusted_value=None)],
+        TargetVariable(identifier='101', original_value="500", adjusted_value="0.5"),
+        TargetVariable(identifier='102', original_value="1000", adjusted_value="1.0"),
+        TargetVariable(identifier='103', original_value="1500", adjusted_value="1.5"),
+        TargetVariable(identifier='104', original_value=None, adjusted_value=None)],
     tpc_ratio="833.3",
     tpc_marker='C',
     error_description=''

--- a/sml_small/editing/thousand_pounds/thousand_pounds.py
+++ b/sml_small/editing/thousand_pounds/thousand_pounds.py
@@ -47,7 +47,7 @@ class TpcMarker(Enum):
 # --- Class Definitions  ---
 # Dataset holding all 'linked questions' with their initial response and final/adjusted values
 @dataclass(frozen=False)
-class Target_variable:
+class TargetVariable:
     identifier: str  # Unique identifer e.g. a question code - q050
     original_value: Optional[str]
     final_value: Optional[str] = None
@@ -55,11 +55,11 @@ class Target_variable:
 
 # Structure of the output dataset
 @dataclass(frozen=True)
-class Thousands_output:
+class ThousandPoundsOutput:
     unique_identifier: Optional[str]  # Unique identifer e.g. a question code - q500
     principal_final_value: Optional[str]  # Output value that may or may not be adjusted
     target_variables: List[
-        Target_variable
+        TargetVariable
     ]  # Output linked values that may or may not be adjusted
     tpc_ratio: Optional[
         str
@@ -83,7 +83,7 @@ def thousand_pounds(
     predictive: Optional[float] = None,
     auxiliary: Optional[float] = None,
     precision: Optional[int] = None,
-) -> Thousands_output:
+) -> ThousandPoundsOutput:
     """
     Calculates a pounds thousands error ratio and if the ratio is between the bounds of the given limits will adjust
     the given principal variable and any linked variables by a factor of 1000.
@@ -106,7 +106,7 @@ def thousand_pounds(
     used throughout method processing
     :type precision: Optional[int]
 
-    :return: Thousands_output: An object containing the
+    :return: ThousandPoundsOutput: An object containing the
                             following attributes:
             - unique_identifier: Unique identifer e.g. a question code - q500
             - principal_original_value: Original provided value
@@ -241,7 +241,7 @@ def thousand_pounds(
                 tpc_marker=tpc_marker.value,
             )
 
-        return Thousands_output(
+        return ThousandPoundsOutput(
             unique_identifier=str(unique_identifier),
             principal_final_value=str(principal_adjusted_value)
             if principal_adjusted_value is not None
@@ -270,20 +270,20 @@ def thousand_pounds(
         raise TPException(f"identifier: {unique_identifier}", error)
 
 
-def create_target_variable_objects(target_variables: dict) -> List[Target_variable]:
+def create_target_variable_objects(target_variables: dict) -> List[TargetVariable]:
     """
     Takes a dictionary of target variables, where key is the identifier and value is the original value and
     creates a list of target_variable objects to be used by the method
 
-    :param target_variables: Dictionary containing values to become Target_variable objects
+    :param target_variables: Dictionary containing values to become TargetVariable objects
     :type target_variables: dict
 
-    :return: target_variables_list, a list of Target_variable objects
-    :rtype: List[Target_variable]
+    :return: target_variables_list, a list of TargetVariable objects
+    :rtype: List[TargetVariable]
     """
     target_variables_list = []
     for key, value in target_variables.items():
-        target_variables_list.append(Target_variable(key, value))
+        target_variables_list.append(TargetVariable(key, value))
     return target_variables_list
 
 
@@ -361,8 +361,8 @@ def check_zero_errors(
     predictive: Optional[Decimal],
     auxiliary: Optional[Decimal],
     principal_variable: Optional[Decimal],
-    target_variables: List[Target_variable],
-) -> Tuple[TpcMarker, Decimal, List[Target_variable]]:
+    target_variables: List[TargetVariable],
+) -> Tuple[TpcMarker, Decimal, List[TargetVariable]]:
     """
     Checks predictive and auxiliary to ensure that there is not only a 0 value available,
     as this will cause a divide by 0 error
@@ -373,15 +373,15 @@ def check_zero_errors(
     :type auxiliary: Optional[Decimal]
     :param principal_variable: Original response value provided for the 'current' period
     :type principal_variable: Optional[Decimal]
-    :param target_variables: list of Target_variable objects that can be corrected
-    :type target_variables: List[Target_variable],
+    :param target_variables: list of TargetVariable objects that can be corrected
+    :type target_variables: List[TargetVariable],
 
     :return: tpc_marker, either method_proceed or stop
     :rtype: TpcMarker
     :return: checked_principal_variable, Decimal value
     :rtype: Decimal
     :return: checked_target_variables, list of variables
-    :rtype: List[Target_variable]
+    :rtype: List[TargetVariable]
     """
     tpc_marker = TpcMarker.METHOD_PROCEED
 
@@ -400,7 +400,7 @@ def check_zero_errors(
         for question in target_variables:
             final_value = question.original_value
             checked_target_variables.append(
-                Target_variable(
+                TargetVariable(
                     identifier=question.identifier,
                     original_value=str(question.original_value)
                     if question.original_value is not None
@@ -513,19 +513,19 @@ def adjust_value(value: Optional[Decimal]) -> Optional[Decimal]:
 
 
 def adjust_target_variables(
-    do_adjustment: bool, target_variables: List[Target_variable]
-) -> List[Target_variable]:
+    do_adjustment: bool, target_variables: List[TargetVariable]
+) -> List[TargetVariable]:
     """
     Method to amend the variables within the target_variables list and append the new values to the individual objects
 
     :param do_adjustment: Determines if the values should be corrected
     :type do_adjustment: bool
-    :param target_variables: list of Target_variable objects that can be corrected
-    :type target_variables: List[Target_variable]
+    :param target_variables: list of TargetVariable objects that can be corrected
+    :type target_variables: List[TargetVariable]
 
     :return: A returned list of target variables with the final_value updated with either the corrected value, or the
     original value if no correction is to be made
-    :rtype: List[Target_variable]
+    :rtype: List[TargetVariable]
     """
     adjusted_target_variables = []
     for question in target_variables:
@@ -534,7 +534,7 @@ def adjust_target_variables(
         else:
             final_value = question.original_value
         adjusted_target_variables.append(
-            Target_variable(
+            TargetVariable(
                 identifier=question.identifier,
                 original_value=str(question.original_value)
                 if question.original_value is not None

--- a/sml_small/editing/totals_and_components/totals_and_components.py
+++ b/sml_small/editing/totals_and_components/totals_and_components.py
@@ -132,7 +132,7 @@ class TotalsAndComponentsOutput:
     ] = None  # the output total which may have been corrected based on user input amend_
     # total variable
     final_components: Optional[
-        str
+        List[str]
     ] = None  # the output components which may have been corrected to match the received
     # predictive value. If corrected the components are scaled proportionally
     # based on the input values
@@ -798,7 +798,7 @@ def error_correction(
     :param original_components: List of Components objects so final values can be amended
     :type original_components: list(ComponentPair)
     ...
-    :return: final_total Final Total value to be output
+    :return: final_total final total value to be output
     :rtype: Decimal
     :return: original_components Updated final values list to be output
     :rtype: list(Decimal)
@@ -835,7 +835,7 @@ def correct_total(
     :param original_components: List of Components objects so final values can be amended
     :type original_components: list(Components_list)
     ...
-    :return:  final_total, Final Total value to be output
+    :return:  final_total, final total value to be output
     :rtype: Decimal
     :return: original_components, Input Component list with final values updated
     :rtype: list(Components_list)
@@ -876,7 +876,7 @@ def correct_components(
     :param total: current total
     :type total: Decimal
     ...
-    :return: final_total, Final Total value to be output
+    :return: final_total, final total value to be output
     :rtype: Decimal
     :return: components Input Component list with final values updated
     :rtype: list(Components_list)

--- a/sml_small/utils/pandas_example.py
+++ b/sml_small/utils/pandas_example.py
@@ -5,6 +5,7 @@ currently this includes Totals and Components, and Thousand Pounds Correction
 For Copyright information, please see LICENCE.
 """
 import pandas as pd
+import re
 
 # We import the wrapper function from the pandas_wrapper
 from sml_small.utils.pandas_wrapper import wrapper
@@ -17,75 +18,151 @@ def load_csv(filepath):
     return df
 
 
-# ---------------------------------------
-# Totals and Components usage
-# ---------------------------------------
-# The code below calls the load_csv function
-# with the filename as an argument
-input_dataframe_totals_and_components = load_csv(
-    "../../tests/editing/totals_and_components/example_data/example_test_data.csv"
-)
-components = ["comp_1", "comp_2", "comp_3", "comp_4"]
+# Function used to extract columns from a dataframe that are treated as a list, e.g comp_1, comp_2, comp_3
+def filter_columns_by_pattern(df, pattern):
+    return [col for col in df.columns if re.match(pattern, col)]
 
-# We call the wrapper function from pandas_wrapper python file
-# passing in the required arguments, which in this case are
-# column names
-totals_and_components_output_columns = [
-    "Absolute Difference",
-    "Low Percent Threshold",
-    "High Percent Threshold",
-    "TCC Marker",
-    "Final Total",
-    "Final Components",
-]
-test_totals_and_components = wrapper(
-    input_dataframe_totals_and_components,
-    "totals_and_components",
-    output_columns=totals_and_components_output_columns,
-    unique_identifier_column="reference",
-    total_column="total",
-    components_list_columns=components,
-    amend_total_column="amend_total",
-    predictive_column="predictive",
-    auxiliary_column="auxiliary",
-    absolute_threshold_column="abs_threshold",
-    percentage_threshold_column="perc_threshold",
-)
 
-# The resulting DataFrame that is stored in the variable test_totals_and_components
-# is then saved to a new CSV file
-# The index=False argument ensures that the row indices are not written
-# to the CSV file
-test_totals_and_components.to_csv(
-    "../../tests/editing/totals_and_components/example_data/example_test_data_pandas_output.csv",
-    index=False,
-)
+# This function takes a given dataframe and will expand a provided column that contains a list
+# into separate columns based on the provided prefix (for plain lists) or attribute (for custom objects)
+def expand_list_column(df, list_column_name, prefix_attribute=None, custom_prefix=None, custom_suffix="final_value"):
+    final_data = []
+
+    for index, row in df.iterrows():
+        data = row.to_dict()
+        list_data = row[list_column_name]
+
+        for i, item in enumerate(list_data, start=1):
+            if prefix_attribute:
+                # If the attribute doesn't exist N/A is added
+                column_prefix = getattr(item, prefix_attribute, 'N/A')
+                column_name = f"{column_prefix}_{custom_suffix}"
+                data[column_name] = item.final_value
+
+            else:
+                column_name = f"{custom_prefix}_{i}"
+                data[column_name] = item
+
+        final_data.append(data)
+
+    return pd.DataFrame(final_data)
+
+
 # ---------------------------------------
-# Thousand Pounds usage
+# Totals and Components usage with Pandas
 # ---------------------------------------
-input_dataframe_thousand_pounds = load_csv(
-    "../../tests/editing/thousand_pounds/example_data/example_test_data.csv"
-)
-target_variables = ["q42", "q43"]
-thousand_pounds_output_columns = [
-    "Principal Final Value",
-    "Target Variables",
-    "TPC Ratio",
-    "TPC Marker",
-]
-test_thousand_pounds = wrapper(
-    input_dataframe_thousand_pounds,
-    "thousand_pounds",
-    output_columns=thousand_pounds_output_columns,
-    unique_identifier_column="RU",
-    principal_variable_column="principal_val",
-    target_variables_columns=target_variables,
-    upper_limit_column="threshold_upper",
-    lower_limit_column="threshold_lower",
-    predictive_column="predictive_val",
-    auxiliary_column="aux_val",
-)
-test_thousand_pounds.to_csv(
-    "../../tests/editing/thousand_pounds/example_data/example_test_data_pandas_output.csv",
-    index=False,
-)
+def run_totals_components_with_pandas(path, input_csv, output_csv):
+    # The code below calls the load_csv function
+    # with the filename as an argument
+    input_dataframe_totals_and_components = load_csv(
+        path+input_csv
+    )
+
+    list_column_pattern = r'comp_\d+'
+    # Use a regular expression to select columns that match the pattern 'comp_' followed by one or more digits.
+    components = filter_columns_by_pattern(input_dataframe_totals_and_components, list_column_pattern)
+
+    # We call the wrapper function from pandas_wrapper python file
+    # passing in the required arguments, which in this case are
+    # column names
+    totals_and_components_output_columns = [
+        "abs_diff",
+        "perc_low",
+        "perc_high",
+        "tcc_marker",
+        "final_total",
+        "final_components",
+    ]
+    test_totals_and_components = wrapper(
+        input_dataframe_totals_and_components,
+        "totals_and_components",
+        output_columns=totals_and_components_output_columns,
+        unique_identifier_column="reference",
+        total_column="total",
+        components_list_columns=components,
+        amend_total_column="amend_total",
+        predictive_column="predictive",
+        auxiliary_column="auxiliary",
+        absolute_threshold_column="abs_threshold",
+        percentage_threshold_column="perc_threshold",
+    )
+
+    # Loop through columns that have list and extract as separate columns
+    final_data = expand_list_column(df=test_totals_and_components, list_column_name="final_components", custom_prefix="final_component")
+
+    # Create a new DataFrame from the final_data list
+    final_df = pd.DataFrame(final_data)
+
+    # Drop the "final_components" column
+    final_df.drop(columns=["final_components"], inplace=True)
+
+    # Move the tpc_marker to be the last column
+    column_to_move = "tcc_marker"
+
+    # Define the desired column order with the specified column at the end
+    column_order = [col for col in final_df.columns if col != column_to_move] + [column_to_move]
+
+    # Create a new DataFrame with the columns in the desired order
+    final_df = final_df[column_order]
+
+    # Write the DataFrame to a CSV, excluding the index column
+    csv_filename = path+output_csv
+    final_df.to_csv(csv_filename, index=False)
+
+
+# ---------------------------------------
+# Thousand Pounds usage with Pandas
+# ---------------------------------------
+def run_thousand_pounds_with_pandas(path, input_csv, output_csv):
+
+    input_dataframe_thousand_pounds = load_csv(path+input_csv)
+
+    # match target variable columns q<number>
+    list_column_pattern = r'q\d+'
+    target_variables = filter_columns_by_pattern(input_dataframe_thousand_pounds, list_column_pattern)
+
+    thousand_pounds_output_columns = [
+        "principal_final_value",
+        "target_variables",
+        "tpc_ratio",
+        "tpc_marker",
+    ]
+    test_thousand_pounds = wrapper(
+        input_dataframe_thousand_pounds,
+        "thousand_pounds",
+        output_columns=thousand_pounds_output_columns,
+        unique_identifier_column="RU",
+        principal_variable_column="principal_val",
+        target_variables_columns=target_variables,
+        upper_limit_column="threshold_upper",
+        lower_limit_column="threshold_lower",
+        predictive_column="predictive_val",
+        auxiliary_column="aux_val",
+    )
+
+    # Expand columns that contain a list of objects (e.g target_variable [TargetVariable(identifier='q42', original_value='32', final_value='0.032'),...])
+    # and create separate columns e.g: q42_final_value
+    final_data = expand_list_column(df=test_thousand_pounds, list_column_name="target_variables", prefix_attribute="identifier")
+
+    # Create a new DataFrame from the final_data list
+    final_df = pd.DataFrame(final_data)
+
+    # Drop the "target_variables" column
+    final_df.drop(columns=["target_variables"], inplace=True)
+
+    # Move the tpc_marker to be the last column
+    column_to_move = "tpc_marker"
+
+    # Define the desired column order with the specified column at the end
+    column_order = [col for col in final_df.columns if col != column_to_move] + [column_to_move]
+
+    # Update the DataFrame with the columns in the desired order
+    final_df = final_df[column_order]
+
+    # Write the DataFrame to a CSV, excluding the index column
+    csv_filename = path+output_csv
+    final_df.to_csv(csv_filename, index=False)
+
+
+run_totals_components_with_pandas("../../tests/editing/totals_and_components/example_data/", "example_test_data.csv", "example_test_data_pandas_output.csv")
+run_thousand_pounds_with_pandas("../../tests/editing/thousand_pounds/example_data/", "example_test_data.csv", "example_test_data_pandas_output.csv")

--- a/sml_small/utils/pandas_example.py
+++ b/sml_small/utils/pandas_example.py
@@ -4,8 +4,9 @@ currently this includes Totals and Components, and Thousand Pounds Correction
 
 For Copyright information, please see LICENCE.
 """
-import pandas as pd
 import re
+
+import pandas as pd
 
 # We import the wrapper function from the pandas_wrapper
 from sml_small.utils.pandas_wrapper import wrapper

--- a/sml_small/utils/pandas_wrapper.py
+++ b/sml_small/utils/pandas_wrapper.py
@@ -85,12 +85,12 @@ def run_totals_and_components(
     totals_and_components_output = pd.DataFrame(
         {
             "Identifier": output.identifier,
-            "Absolute Difference": output.absolute_difference,
-            "Low Percent Threshold": output.low_percent_threshold,
-            "High Percent Threshold": output.high_percent_threshold,
-            "Final Total": output.final_total,
-            "Final Components": [output.final_components],
-            "TCC Marker": output.tcc_marker,
+            "abs_diff": output.absolute_difference,
+            "perc_low": output.low_percent_threshold,
+            "perc_high": output.high_percent_threshold,
+            "final_total": output.final_total,
+            "final_components": [output.final_components],
+            "tcc_marker": output.tcc_marker,
         },
         index=[index_number],
     )
@@ -154,10 +154,10 @@ def run_thousand_pounds(
     thousand_pounds_output = pd.DataFrame(
         {
             "Principal Identifier": output.unique_identifier,
-            "Principal Final Value": output.principal_final_value,
-            "Target Variables": [output.target_variables],
-            "TPC Ratio": output.tpc_ratio,
-            "TPC Marker": output.tpc_marker,
+            "principal_final_value": output.principal_final_value,
+            "target_variables": [output.target_variables],
+            "tpc_ratio": output.tpc_ratio,
+            "tpc_marker": output.tpc_marker,
         },
         index=[index_number],
     )
@@ -218,6 +218,7 @@ def wrapper(
         lambda row: function_mappings[method](row, row.name, **method_input),
         axis=1,
     )
+
     output_dataframe = pd.concat(list(output_dataframe), ignore_index=True)
     frames = [input_frame, output_dataframe]
     # concatenate the two dataframes together and output

--- a/tests/editing/thousand_pounds/tests/test_thousand_pounds.py
+++ b/tests/editing/thousand_pounds/tests/test_thousand_pounds.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sml_small.editing.thousand_pounds.thousand_pounds import (Target_variable, Thousands_output, TpcMarker,
+from sml_small.editing.thousand_pounds.thousand_pounds import (TargetVariable, ThousandPoundsOutput, TpcMarker,
                                                                TPException, adjust_target_variables, adjust_value,
                                                                calculate_error_ratio, create_target_variable_objects,
                                                                determine_predictive_value, determine_tpc_marker,
@@ -32,14 +32,14 @@ class TestThousandPounds:
                     "q104": 0,
                 },
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "q100",
                     "50000",
                     [
-                        Target_variable("q101", "500", "0.5"),
-                        Target_variable("q102", "1000", "1"),
-                        Target_variable("q103", "12345", "12.345"),
-                        Target_variable("q104", "0", "0"),
+                        TargetVariable("q101", "500", "0.5"),
+                        TargetVariable("q102", "1000", "1"),
+                        TargetVariable("q103", "12345", "12.345"),
+                        TargetVariable("q104", "0", "0"),
                     ],
                     "1000",
                     "C",
@@ -55,7 +55,7 @@ class TestThousandPounds:
                 350,
                 {},
                 28,
-                Thousands_output("q200", "60000", [], "400", "C"),
+                ThousandPoundsOutput("q200", "60000", [], "400", "C"),
                 "Test 2: Given config(missing auxiliary) - outputs adjusted for all target variables",
             ),
             (
@@ -67,7 +67,7 @@ class TestThousandPounds:
                 350,
                 {},
                 28,
-                Thousands_output("q300", "269.98", [], "1349.9", "C"),
+                ThousandPoundsOutput("q300", "269.98", [], "1349.9", "C"),
                 "Test 3: Given config(missing predictive) - outputs adjusted for all target variables",
             ),
             (
@@ -99,12 +99,12 @@ class TestThousandPounds:
                     "q452": 1000,
                 },
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "q410",
                     "8000",
                     [
-                        Target_variable("q451", "500", "500"),
-                        Target_variable("q452", "1000", "1000"),
+                        TargetVariable("q451", "500", "500"),
+                        TargetVariable("q452", "1000", "1000"),
                     ],
                     None,
                     "S",
@@ -120,12 +120,12 @@ class TestThousandPounds:
                 350,
                 {"q451": 500, "q452": 1000},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "q450",
                     "8000",
                     [
-                        Target_variable("q451", "500", "500"),
-                        Target_variable("q452", "1000", "1000"),
+                        TargetVariable("q451", "500", "500"),
+                        TargetVariable("q452", "1000", "1000"),
                     ],
                     None,
                     "S",
@@ -156,12 +156,12 @@ class TestThousandPounds:
                 350,
                 {"q601": 500, "q602": 1000},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "q600",
                     "0",
                     [
-                        Target_variable("q601", "500", "500"),
-                        Target_variable("q602", "1000", "1000"),
+                        TargetVariable("q601", "500", "500"),
+                        TargetVariable("q602", "1000", "1000"),
                     ],
                     "0",
                     "N",
@@ -177,10 +177,10 @@ class TestThousandPounds:
                 350,
                 {"q701": 500},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "q700",
                     "3500",
-                    [Target_variable("q701", "500", "500")],
+                    [TargetVariable("q701", "500", "500")],
                     "350",
                     "N",
                 ),
@@ -195,10 +195,10 @@ class TestThousandPounds:
                 350,  # lower limit
                 {"q801": 500},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "q800",
                     "13500",
-                    [Target_variable("q801", "500", "500")],
+                    [TargetVariable("q801", "500", "500")],
                     "1350",
                     "N",
                 ),
@@ -324,7 +324,7 @@ class TestThousandPounds:
         expected,
         test_id,
     ):
-        if isinstance(expected, Thousands_output):
+        if isinstance(expected, ThousandPoundsOutput):
             try:
                 result = thousand_pounds(
                     unique_identifier=unique_identifier,
@@ -375,12 +375,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 32, "q43": 97},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-1-A",
                     "706",
                     [
-                        Target_variable("q42", "32", "32"),
-                        Target_variable("q43", "97", "97"),
+                        TargetVariable("q42", "32", "32"),
+                        TargetVariable("q43", "97", "97"),
                     ],
                     "1.166942148760330578512396694",
                     "N",
@@ -396,12 +396,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 287, "q43": 199},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-1-B",
                     "381",
                     [
-                        Target_variable("q42", "287", "287"),
-                        Target_variable("q43", "199", "199"),
+                        TargetVariable("q42", "287", "287"),
+                        TargetVariable("q43", "199", "199"),
                     ],
                     "0.9525",
                     "N",
@@ -417,12 +417,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 32, "q43": 97},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-2-A",
                     "823650",
                     [
-                        Target_variable("q42", "32", "32"),
-                        Target_variable("q43", "97", "97"),
+                        TargetVariable("q42", "32", "32"),
+                        TargetVariable("q43", "97", "97"),
                     ],
                     "1361.404958677685950413223140",
                     "N",
@@ -438,12 +438,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 7161, "q43": 759},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-2-B",
                     "11638071",
                     [
-                        Target_variable("q42", "7161", "7161"),
-                        Target_variable("q43", "759", "759"),
+                        TargetVariable("q42", "7161", "7161"),
+                        TargetVariable("q43", "759", "759"),
                     ],
                     "3343.312553863832232117207699",
                     "N",
@@ -459,12 +459,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 32, "q43": 97},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-3-A",
                     "151250",
                     [
-                        Target_variable("q42", "32", "32"),
-                        Target_variable("q43", "97", "97"),
+                        TargetVariable("q42", "32", "32"),
+                        TargetVariable("q43", "97", "97"),
                     ],
                     "250",
                     "N",
@@ -480,12 +480,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 3900, "q43": 272},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-3-B",
                     "5750",
                     [
-                        Target_variable("q42", "3900", "3900"),
-                        Target_variable("q43", "272", "272"),
+                        TargetVariable("q42", "3900", "3900"),
+                        TargetVariable("q43", "272", "272"),
                     ],
                     "250",
                     "N",
@@ -501,12 +501,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 32, "q43": 97},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-4-A",
                     "816750",
                     [
-                        Target_variable("q42", "32", "32"),
-                        Target_variable("q43", "97", "97"),
+                        TargetVariable("q42", "32", "32"),
+                        TargetVariable("q43", "97", "97"),
                     ],
                     "1350",
                     "N",
@@ -522,12 +522,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 29, "q43": 7},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-4-B",
                     "31050",
                     [
-                        Target_variable("q42", "29", "29"),
-                        Target_variable("q43", "7", "7"),
+                        TargetVariable("q42", "29", "29"),
+                        TargetVariable("q43", "7", "7"),
                     ],
                     "1350",
                     "N",
@@ -543,12 +543,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 3238, "q43": 97},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-5-A",
                     "716.75",
                     [
-                        Target_variable("q42", "3238", "3.238"),
-                        Target_variable("q43", "97", "0.097"),
+                        TargetVariable("q42", "3238", "3.238"),
+                        TargetVariable("q43", "97", "0.097"),
                     ],
                     "1184.710743801652892561983471",
                     "C",
@@ -565,12 +565,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 29, "q43": 7753},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-5-B",
                     "21.758",
                     [
-                        Target_variable("q42", "29", "0.029"),
-                        Target_variable("q43", "7753", "7.753"),
+                        TargetVariable("q42", "29", "0.029"),
+                        TargetVariable("q43", "7753", "7.753"),
                     ],
                     "946",
                     "C",
@@ -587,12 +587,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 3238, "q43": 97},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-6-A",
                     "716.75",
                     [
-                        Target_variable("q42", "3238", "3.238"),
-                        Target_variable("q43", "97", "0.097"),
+                        TargetVariable("q42", "3238", "3.238"),
+                        TargetVariable("q43", "97", "0.097"),
                     ],
                     "1184.710743801652892561983471",
                     "C",
@@ -609,12 +609,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 29, "q43": 7753},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-6-B",
                     "21.758",
                     [
-                        Target_variable("q42", "29", "0.029"),
-                        Target_variable("q43", "7753", "7.753"),
+                        TargetVariable("q42", "29", "0.029"),
+                        TargetVariable("q43", "7753", "7.753"),
                     ],
                     "946",
                     "C",
@@ -631,12 +631,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 3238, "q43": 97},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-7-A",
                     "716750",
                     [
-                        Target_variable("q42", "3238", "3238"),
-                        Target_variable("q43", "97", "97"),
+                        TargetVariable("q42", "3238", "3238"),
+                        TargetVariable("q43", "97", "97"),
                     ],
                     None,
                     "S",
@@ -653,12 +653,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 29, "q43": 7753},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-7-B",
                     "21758",
                     [
-                        Target_variable("q42", "29", "29"),
-                        Target_variable("q43", "7753", "7753"),
+                        TargetVariable("q42", "29", "29"),
+                        TargetVariable("q43", "7753", "7753"),
                     ],
                     None,
                     "S",
@@ -675,12 +675,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 3238, "q43": 97},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-8-A",
                     "716750",
                     [
-                        Target_variable("q42", "3238", "3238"),
-                        Target_variable("q43", "97", "97"),
+                        TargetVariable("q42", "3238", "3238"),
+                        TargetVariable("q43", "97", "97"),
                     ],
                     None,
                     "S",
@@ -697,12 +697,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 29, "q43": 7753},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-8-B",
                     "21758",
                     [
-                        Target_variable("q42", "29", "29"),
-                        Target_variable("q43", "7753", "7753"),
+                        TargetVariable("q42", "29", "29"),
+                        TargetVariable("q43", "7753", "7753"),
                     ],
                     None,
                     "S",
@@ -719,12 +719,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 3238, "q43": 97},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-9-A",
                     "716.75",
                     [
-                        Target_variable("q42", "3238", "3.238"),
-                        Target_variable("q43", "97", "0.097"),
+                        TargetVariable("q42", "3238", "3.238"),
+                        TargetVariable("q43", "97", "0.097"),
                     ],
                     "1184.710743801652892561983471",
                     "C",
@@ -741,12 +741,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 29, "q43": 7753},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-9-B",
                     "21.758",
                     [
-                        Target_variable("q42", "29", "0.029"),
-                        Target_variable("q43", "7753", "7.753"),
+                        TargetVariable("q42", "29", "0.029"),
+                        TargetVariable("q43", "7753", "7.753"),
                     ],
                     "946",
                     "C",
@@ -763,12 +763,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 3238, "q43": None},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-10-A",
                     "716.75",
                     [
-                        Target_variable("q42", "3238", "3.238"),
-                        Target_variable("q43", None, None),
+                        TargetVariable("q42", "3238", "3.238"),
+                        TargetVariable("q43", None, None),
                     ],
                     "1184.710743801652892561983471",
                     "C",
@@ -787,12 +787,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": None, "q43": 7753},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-10-B",
                     "21.758",
                     [
-                        Target_variable("q42", None, None),
-                        Target_variable("q43", "7753", "7.753"),
+                        TargetVariable("q42", None, None),
+                        TargetVariable("q43", "7753", "7.753"),
                     ],
                     "946",
                     "C",
@@ -810,12 +810,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": None, "q43": None},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-11-A",
                     "716.75",
                     [
-                        Target_variable("q42", None, None),
-                        Target_variable("q43", None, None),
+                        TargetVariable("q42", None, None),
+                        TargetVariable("q43", None, None),
                     ],
                     "1184.710743801652892561983471",
                     "C",
@@ -832,12 +832,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": None, "q43": None},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-11-B",
                     "21.758",
                     [
-                        Target_variable("q42", None, None),
-                        Target_variable("q43", None, None),
+                        TargetVariable("q42", None, None),
+                        TargetVariable("q43", None, None),
                     ],
                     "946",
                     "C",
@@ -854,12 +854,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 3238, "q43": 97},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-12-A",
                     "716.75",
                     [
-                        Target_variable("q42", "3238", "3.238"),
-                        Target_variable("q43", "97", "0.097"),
+                        TargetVariable("q42", "3238", "3.238"),
+                        TargetVariable("q43", "97", "0.097"),
                     ],
                     "1184.710743801652892561983471",
                     "C",
@@ -876,12 +876,12 @@ class TestThousandPoundsUAT:
                 250,
                 {"q42": 29, "q43": 7753},
                 28,
-                Thousands_output(
+                ThousandPoundsOutput(
                     "UAT-Sheet-12-B",
                     "21.758",
                     [
-                        Target_variable("q42", "29", "0.029"),
-                        Target_variable("q43", "7753", "7.753"),
+                        TargetVariable("q42", "29", "0.029"),
+                        TargetVariable("q43", "7753", "7.753"),
                     ],
                     "946",
                     "C",
@@ -904,7 +904,7 @@ class TestThousandPoundsUAT:
         expected,
         test_id,
     ):
-        if isinstance(expected, Thousands_output):
+        if isinstance(expected, ThousandPoundsOutput):
             try:
                 result = thousand_pounds(
                     unique_identifier=unique_identifier,
@@ -947,7 +947,7 @@ class TestCreateTargetVariableObjects:
         [
             (
                 {"Q123": 400, "Q983": 21},
-                [Target_variable("Q123", 400, None), Target_variable("Q983", 21, None)],
+                [TargetVariable("Q123", 400, None), TargetVariable("Q983", 21, None)],
                 "Test 1: Dictionary structure input",
             )
         ],
@@ -1427,28 +1427,28 @@ class TestAdjustTargetVariables:
         [
             (
                 True,
-                [Target_variable("q501", 500000.4332), Target_variable("q502", 1000)],
+                [TargetVariable("q501", 500000.4332), TargetVariable("q502", 1000)],
                 [
-                    Target_variable("q501", "500000.4332", "500.00043320000003"),
-                    Target_variable("q502", "1000", "1.0"),
+                    TargetVariable("q501", "500000.4332", "500.00043320000003"),
+                    TargetVariable("q502", "1000", "1.0"),
                 ],
                 "Test 1: do_adjustment == True, Target variable is appropriately rounded down",
             ),
             (
                 True,
-                [Target_variable("q501", 999999.99999), Target_variable("q502", 1000)],
+                [TargetVariable("q501", 999999.99999), TargetVariable("q502", 1000)],
                 [
-                    Target_variable("q501", "999999.99999", "999.99999999"),
-                    Target_variable("q502", "1000", "1.0"),
+                    TargetVariable("q501", "999999.99999", "999.99999999"),
+                    TargetVariable("q502", "1000", "1.0"),
                 ],
                 "Test 2: Target variable is appropriately rounded up",
             ),
             (
                 False,
-                [Target_variable("q501", 500), Target_variable("q502", 1000)],
+                [TargetVariable("q501", 500), TargetVariable("q502", 1000)],
                 [
-                    Target_variable("q501", "500", "500"),
-                    Target_variable("q502", "1000", "1000"),
+                    TargetVariable("q501", "500", "500"),
+                    TargetVariable("q502", "1000", "1000"),
                 ],
                 "Test 3: do_adjustment == False Target variable is not rounded",
             ),

--- a/tests/editing/totals_and_components/example_data/example_test_data.csv
+++ b/tests/editing/totals_and_components/example_data/example_test_data.csv
@@ -1,7 +1,7 @@
-reference,period,total,comp_1,comp_2,comp_3,comp_4,comp_sum,amend_total,predictive,auxiliary,abs_threshold,perc_threshold,abs_diff,perc_low,perc_high,TCC_marker,final_total,final_comp_1,final_comp_2,final_comp_3,final_comp_4
-A,202301,1625,632,732,99,162,1625,TRUE,1625,,11,,0,,,N,1625,632,732,99,162
-B,202301,10817,9201,866,632,112,10811,TRUE,10817,,11,,6,,,T,10811,9201,866,632,112
-C,202301,90,90,0,4,6,100,FALSE,90,,,0.1,,90,110,C,90,81,0,3.6,5.4
-D,202301,1964,632,732,99,162,1625,TRUE,1964,,25,0.1,339,1462.5,1787.5,M,1964,632,732,99,162
-E,202301,306,240,0,30,10,280,TRUE,306,,25,0.1,26,252,308,T,280,240,0,30,10
-F,202301,11,0,0,0,0,0,TRUE,11,,11,,11,,,S,11,0,0,0,0
+reference,period,total,comp_1,comp_2,comp_3,comp_4,comp_sum,amend_total,predictive,auxiliary,abs_threshold,perc_threshold
+A,202301,1625,632,732,99,162,1625,TRUE,1625,,11,
+B,202301,10817,9201,866,632,112,10811,TRUE,10817,,11,
+C,202301,90,90,0,4,6,100,FALSE,90,,,0.1
+D,202301,1964,632,732,99,162,1625,TRUE,1964,,25,0.1
+E,202301,306,240,0,30,10,280,TRUE,306,,25,0.1
+F,202301,11,0,0,0,0,0,TRUE,11,,11,

--- a/tests/editing/totals_and_components/example_data/example_test_data_pandas_output.csv
+++ b/tests/editing/totals_and_components/example_data/example_test_data_pandas_output.csv
@@ -1,7 +1,7 @@
-reference,total,comp_1,comp_2,comp_3,comp_4,amend_total,predictive,auxiliary,abs_threshold,perc_threshold,Absolute Difference,Low Percent Threshold,High Percent Threshold,TCC Marker,Final Total,Final Components
-A,1625,632,732,99,162,True,1625,,11.0,,0,,,N,1625,"['632', '732', '99', '162']"
-B,10817,9201,866,632,112,True,10817,,11.0,,6,,,T,10811,"['9201', '866', '632', '112']"
-C,90,90,0,4,6,False,90,,,0.1,,90.0,110.0,C,90,"['81.0', '0', '3.60', '5.40']"
-D,1964,632,732,99,162,True,1964,,25.0,0.1,339,1462.5,1787.5,M,1964,"['632', '732', '99', '162']"
-E,306,240,0,30,10,True,306,,25.0,0.1,26,252.0,308.0,T,280,"['240', '0', '30', '10']"
-F,11,0,0,0,0,True,11,,11.0,,,,,S,11,"['0', '0', '0', '0']"
+reference,total,comp_1,comp_2,comp_3,comp_4,amend_total,predictive,auxiliary,abs_threshold,perc_threshold,abs_diff,perc_low,perc_high,final_total,final_component_1,final_component_2,final_component_3,final_component_4,tcc_marker
+A,1625,632,732,99,162,True,1625,,11.0,,0,,,1625,632,732,99,162,N
+B,10817,9201,866,632,112,True,10817,,11.0,,6,,,10811,9201,866,632,112,T
+C,90,90,0,4,6,False,90,,,0.1,,90.0,110.0,90,81.0,0,3.60,5.40,C
+D,1964,632,732,99,162,True,1964,,25.0,0.1,339,1462.5,1787.5,1964,632,732,99,162,M
+E,306,240,0,30,10,True,306,,25.0,0.1,26,252.0,308.0,280,240,0,30,10,T
+F,11,0,0,0,0,True,11,,11.0,,,,,11,0,0,0,0,S


### PR DESCRIPTION
## Synopsis

The demo pandas example for totals and components and thousand pounds correction is not formatting the output CSV as per the provided UAT CSV files.  MQD have asked that by default the pandas example should expand any cell that is a list into individual columns.

E.g 
Target Variable 
target_variable [TargetVariable(identifier='q42', original_value='32', final_value='0.032'),...]

should written as separate columns for each identifier with the final_value as the cell value

E.g 
q42
0.032

Similarly, the totals and components example should expand the Final Components column into separate col_1, col_2, ... headings

## Checklist

- [X] Documentation created/updated
- [X] Tests created/updated

## Description

**README.md/thousand_pounds.py/test_thousand_pounds.py**
PEP8 Formatting states that class names should be camel case.  Totals and components code follows this format but thousand pounds does not, updated classes in thousand_pounds to use the correct format for naming.

**totals_and_components.py**
Type hinting corrected to show the function returns a list of final_components
Minor docstring updates

**example.py**
filter_columns_by_pattern() to handle input columns (e.g component_1, component_2,...) that could be dynamic.

expand_list_column() to handle output columns (e.g TargetVariables) that could be dynamic and separate into a separate datastructure where each element of the list is mapped to a separate column.

Updated the code so that thousand pounds and totals and components examples are now functions that take a path, input_csv and output_csv filename.

Columns that were previously declared as having spaces (e.g Absolute Difference) have been updated to be snake case and use the naming from the example UAT CSVs.

The output returned from the main method (e.g totals_and_components) has some minor post-processing to ensure the column headings and data align with UAT CSV files before being written as CSV output files.

**pandas_wrapper.py**
Columns that were previously declared as having spaces (e.g Absolute Difference) have been updated to be snake case and use the naming from the example UAT CSVs.

**example_test_data.csv**
Updated so that it only includes the input columns as this is data input for the totals_and_components method

**example_test_data_pandas_output.csv**
Kept in git (for now) to show the example changes implemented by this PR. 


