### PR TITLE
WP: Created catalog-info.yaml file for SDP integration

### DIFF
--- a/catalog-infp.yaml
+++ b/catalog-infp.yaml
@@ -1,0 +1,19 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: sml-python-small
+  description: Statistical Methods Library for Python Pandas methods used in the Statistical Production Platform (SPP).
+  annotations:
+    jira/project-key: SPP
+    github.com/project-slug: ONSdigital/sml-python-small
+  tags:
+    - python
+    - sml
+  links:
+    - url: https://statisticalmethodslibrary.ons.gov.uk
+      title: SML Website
+      icon: search
+spec:
+  type: library
+  lifecycle: production
+  owner: group:spp-sml


### PR DESCRIPTION
## Synopsis

Created a catalog-info.yaml for software developer portal integration. This will let the user to access the GitHub repository in the backstage instance.

Briefly describe the purpose of the pr.

- SDP integration