### PR TITLE
Typo in comments (error list)

### DIFF
--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -66,7 +66,7 @@ jobs:
           reporter: java-junit
           fail-on-error: false
       - name: upload-coverage-report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: tests/htmlcov/

--- a/sml_small/date_adjustment.py
+++ b/sml_small/date_adjustment.py
@@ -113,7 +113,7 @@ def date_adjustment(
             * E08: A required trading weight for calculating weight n has a negative value.
             * E09: Contributors return does not cover any of expected period.
             * E10: The sum of trading day weights over contributors returned period is zero.
-            * E11: The sum of trading day weights over contributors returned period is zero.
+            * E11: The sum of trading day weights over actual returned period is zero.
             * E12: A required record for calculating midpoint date is missing from the
                     trading weights table.
             * E13: A required record for setting APS and APE by midpoint is missing from or


### PR DESCRIPTION
Hi. It's my belief that the E11 error message shouldn't look identical to the E10 message from looking at the code, so have updated the text of the comment. I realise this seems a bit petty, but we show the text (not just the code) to the users, and would like to have it confirmed that this is the true meaning of the error.